### PR TITLE
increase thread-stack-size to 128k on musl

### DIFF
--- a/src/juci_ws_server.c
+++ b/src/juci_ws_server.c
@@ -416,6 +416,9 @@ static int _websocket_recv(juci_server_t socket, struct ubus_message **msg, unsi
 
 juci_server_t juci_ws_server_new(const char *www_root){
 	struct ubus_srv_ws *self = calloc(1, sizeof(struct ubus_srv_ws)); 
+
+	pthread_attr_t attr;
+
 	assert(self); 
 	self->www_root = (www_root)?www_root:"/www/"; 
 	self->protocols = calloc(2, sizeof(struct lws_protocols)); 
@@ -439,6 +442,8 @@ juci_server_t juci_ws_server_new(const char *www_root){
 		.userdata = _websocket_userdata
 	}; 
 	self->api = &api; 
-	pthread_create(&self->thread, NULL, _websocket_server_thread, self); 
+	pthread_attr_init(&attr);
+	pthread_attr_setstacksize(&attr, 128*1024);
+	pthread_create(&self->thread, &attr, _websocket_server_thread, self); 
 	return &self->api; 
 }


### PR DESCRIPTION
musl provides a default stack size of 80k for new threads [0], which is at the moment not enough for jucid, resulting in unaccessible memory and segfaults. This merge increases the stack-size to 128k which seems to be enough.

[0] http://wiki.musl-libc.org/wiki/Functional_differences_from_glibc#Thread_stack_size
